### PR TITLE
Sprint <- calendar-currentStateLogic: Add currentState logic & data population

### DIFF
--- a/source/calendar/calendar-js.js
+++ b/source/calendar/calendar-js.js
@@ -14,6 +14,15 @@ function getDaysInMonth(year, month) {
     return new Date(year, month, 0).getDate();
   }
 
+/**
+ * Returns the first day of the week of given month year.
+ * If `month`/01/`year` is a Sunday, it returns 0.
+ * If Monday, returns 1. And so on.
+ * 
+ * @param {year} year
+ * @param {month} month 
+ * @returns the first day of the week of given month year
+ */
 function getFirstDay(year, month) {
     return new Date(year, month - 1, 1).getDay();
 }
@@ -101,7 +110,7 @@ function createGrids(year, month){
  */
 function changePage(date){
     //update currentState for edit-page
-    localStorage.setItem("currentState", date);
+    localStorage.setItem('currentState', JSON.stringify(date));
     location.replace('../edit-page/edit-page.html');
 }
 
@@ -122,13 +131,30 @@ function deleteGrids(){
 }
 
 function init(){
-    const date = new Date(); //get today's date
-    const year = date.getFullYear(); //current year
-    const month = date.getMonth() + 1; //current month
+    //currentState logic
+    const currentState = JSON.parse(localStorage.getItem('currentState'));
 
-    createGrids(year, month);
+    let year = 0;
+    let month = 0;
+
+    //case: render today.
+    if (!currentState){
+        const todayDate = new Date(); //get today's date
+        year = todayDate.getFullYear(); //current year
+        month = todayDate.getMonth() + 1; //current month
+        createGrids(year, month);
+    }
+    //case: render currentState.
+    else{
+        const dateArr = currentState.split("-");
+        year = dateArr[0];
+        month = dateArr[1];
+
+        createGrids(year, month);
+    }
     
-    const dateSelectorElement = document.querySelector('#start');
+    const dateSelectorElement = document.querySelector('#dateSelect');
+    dateSelectorElement.setAttribute('value',`${year}-${month}`);
 
     dateSelectorElement.addEventListener('change', () => {
         deleteGrids(); //refresh the calender before generating.

--- a/source/calendar/calendar-js.js
+++ b/source/calendar/calendar-js.js
@@ -1,10 +1,16 @@
 window.addEventListener('DOMContentLoaded', init);
 
-
+/**
+ * Returns the number of days in `month` and `year`.
+ * 
+ * @param {year} year 
+ * @param {month} month 
+ * @returns the number of days in `month` and `year`.
+ */
 function getDaysInMonth(year, month) {
     // month starts at 0 index
     //passing in 0 to get the previous month
-    //ex: (2022, 07, 0) => # of days in June.
+    //ex: (2022, 07, 0) => gives us # of days in June.
     return new Date(year, month, 0).getDate();
   }
 
@@ -12,54 +18,101 @@ function getFirstDay(year, month) {
     return new Date(year, month - 1, 1).getDay();
 }
 
-
+/**
+ * Generate the relavant dates in the calendar and populates it with data from `localStorage`.
+ * 
+ * **Assumptions**: a 7x7 container with class name `.date-grid` exists. 
+ * 
+ * **Technical Details**: If the first day of `month` starts on day of the week `w`--i.e. 
+ * Sunday is `0`, Monday is  `1`--then `w` divs are inserted. The rest of the grid is filled with 
+ * divs with date and all of the dates that is an `entry` in `localStorage`, it is modified to be 
+ * clickable.
+ * 
+ * @param {year} year 
+ * @param {month} month 
+ */
 function createGrids(year, month){
+    // TODO: `colors` should be retrieved from `localStorage`. Placeholder data for now.
+    const colors = {
+        terrible: "red",
+        bad: "orange",
+        neutral: "blue",
+        good: "green",
+        great: "pink"
+    }
 
     const today = new Date();
     const firstDay = getFirstDay(year, month);
     const numberDays = getDaysInMonth(year, month);
-    console.log(numberDays);
-    console.log(firstDay);
 
-    const target = document.querySelector('.date-grid')
+    const target = document.querySelector('.date-grid');
     
-    //grids before first day of the month
+    //create empty divs before first day of the month
     for(let i = 0; i < firstDay; i++){
         const grid = document.createElement('div');
         target.appendChild(grid);
     }
 
-    //grids in the month
-    for(let i = 1; i <= numberDays; i++){
-        const dayElement = document.createElement('div');
+    //create date elements
+    for(let currDay = 1; currDay <= numberDays; currDay++){
+        // Create elements.
+        //create date element.
+        const dateElement = document.createElement('div');
+        target.appendChild(dateElement);
+        
+        //create label for day number of the month.
         const dayDiv = document.createElement('div');
-        const day = document.createTextNode(i);
-        target.appendChild(dayElement);
-        dayElement.appendChild(dayDiv);
-        dayDiv.className = month + "-" + i + "-" + year;
-        dayDiv.appendChild(day);
+        dayDiv.className = month + "-" + currDay + "-" + year;
+        //create text element for the number itself.
+        const dayNumber = document.createTextNode(currDay);
+        dayDiv.appendChild(dayNumber);
+        dateElement.appendChild(dayDiv);
         
-        if(today.getFullYear() == year && today.getDate() == i && today.getMonth() + 1 == month){
-            dayElement.className = 'day today';
+        // Classify date & Populate with data.
+        //if current day is today,
+        if(today.getFullYear() == year && 
+           today.getDate() == currDay && 
+           today.getMonth() + 1 == month){
+            dateElement.className = 'day today';
         }
-        else
-            dayElement.className = 'day';
+        //if not today,
+        else{
+            dateElement.className = 'day';
+        }
     
-        
-        if(localStorage.getItem(`${year}-${month}-${i}`) != null){
-            dayElement.setAttribute('onclick', `changePage("${year}-${month}-${i}")`);
+        //if entry exists for currDay, populate the date element with data in entry.
+        const rawEntry = localStorage.getItem(`${year}-${month}-${currDay}`);
+        const entry = JSON.parse(rawEntry);
+        if(entry != null){
+
+            //link function for changing page
+            dateElement.setAttribute('onclick', `changePage("${year}-${month}-${currDay}")`);
+
+            //color
+            dateElement.style = "background-color: " + colors[entry.rating];
         }
     }
 }
 
+/**
+ * Changes to the edit-page. `date` is passed onto `key: currentState` in the `localStorage`. 
+ * 
+ * @param {date} date 
+ */
 function changePage(date){
-    //current date
-    //alert(date);
+    //update currentState for edit-page
     localStorage.setItem("currentState", date);
     location.replace('../edit-page/edit-page.html');
 }
 
-//delete the whole grids for refreshing purpose.
+/**
+ * Deletes all the day elements in calendar container.
+ * 
+ * All the div elements in the .date-grid container is removed.
+ * 
+ * @example
+ * deleteGrids();
+ */
 function deleteGrids(){
     const target = document.querySelector('.date-grid');
     const child = target.querySelectorAll('div')
@@ -69,18 +122,19 @@ function deleteGrids(){
 }
 
 function init(){
-
     const date = new Date(); //get today's date
     const year = date.getFullYear(); //current year
     const month = date.getMonth() + 1; //current month
+
     createGrids(year, month);
     
-    const test = document.querySelector('#start');
+    const dateSelectorElement = document.querySelector('#start');
 
-    test.addEventListener('change', ()=>{
+    dateSelectorElement.addEventListener('change', () => {
         deleteGrids(); //refresh the calender before generating.
-        const st = test.value.split("-");   
-        createGrids(st[0] - 0, st[1] - 0);
+        const dateArr = dateSelectorElement.value.split("-"); // "year-month"
+        const year = dateArr[0] - 0;
+        const month = dateArr[1] - 0;
+        createGrids(year, month);
     });
-
 }

--- a/source/calendar/calendar-style.css
+++ b/source/calendar/calendar-style.css
@@ -71,7 +71,3 @@ main {
     border-width: 2px;
     border-color: black;
 }
-
-/* .day.color {
-
-} */

--- a/source/calendar/index.html
+++ b/source/calendar/index.html
@@ -22,9 +22,9 @@
         <!-- Calendar -->
         <div class="calendar">
             <!-- Already has option of "This Month"-->
-            <label for="start" class="select">Select Month & Year:</label>
+            <label for="dateSelect" class="selectLabel">Select Month & Year:</label>
             <!-- Start at 2022-01, value = "" for empty inputs -->
-            <input type="month" id="start" name="start"
+            <input type="month" id="dateSelect" name="start"
                 min="2022-01" value="">            
             <div class="date-grid">
                 <!-- First row used for labeling. -->


### PR DESCRIPTION
### Added `currentState` logic.
* if `currentState` is `null` or doesn't exists, today's date is loaded.
* if `currentState` has a value, that `month-year` is loaded.

### Data population
* `colors` isn't loaded from `localStorage`; there is a place holder! (Line 36)
<img width="498" alt="colorsPlaceholder" src="https://user-images.githubusercontent.com/60344816/202836508-8541c6e2-b7f1-4f0f-a1fd-2d1c01d7e54f.png">

* colors on the dates.
  * EX) with following data:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/60344816/202837276-459d2842-5f48-4419-9a71-9d9513f82626.png">
<img width="470" alt="image" src="https://user-images.githubusercontent.com/60344816/202837247-06d34a12-a3ea-4980-aeb8-507dbb67c466.png">


### Minor bug fixes
* current date is loaded into `dateSelector` when initially loading into the `calendar` page.
![image](https://user-images.githubusercontent.com/60344816/202837592-a7038760-c88e-4468-ac32-508709abe265.png)

* #16 not resolved, so it is resolved here.

### Documentation
* added function headers.
* added comments.
* renamed variables.
* changed the structure of the code.
